### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-scribus.io


### PR DESCRIPTION
Motivation:

The domain name scribus.io does not resolve

Modification:

remove the CNAME file

Result:

scribusproject.github.io should work fine